### PR TITLE
feat: add POST method and body support to multi_format_api_handler

### DIFF
--- a/mindsdb/integrations/handlers/multi_format_api_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/connection_args.py
@@ -15,6 +15,18 @@ connection_args = OrderedDict(
         'required': False,
         'label': 'Default Headers',
     },
+    method={
+        'type': ARG_TYPE.STR,
+        'description': 'HTTP method to use: GET or POST. Default is GET.',
+        'required': False,
+        'label': 'HTTP Method',
+    },
+    body={
+        'type': ARG_TYPE.DICT,
+        'description': 'Default request body sent with POST requests as JSON.',
+        'required': False,
+        'label': 'Default Request Body',
+    },
     timeout={
         'type': ARG_TYPE.INT,
         'description': 'Default request timeout in seconds. Default is 30 seconds.',
@@ -36,6 +48,8 @@ connection_args_example = OrderedDict(
         'Authorization': 'Bearer YOUR_TOKEN_HERE',
         'X-API-Key': 'your-api-key',
     },
+    method='POST',
+    body={'query': 'search term', 'variables': {}},
     timeout=60,
     max_content_size=50,  # 50 MB limit
 )

--- a/mindsdb/integrations/handlers/multi_format_api_handler/format_parsers.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/format_parsers.py
@@ -79,21 +79,23 @@ def parse_json(content: str) -> pd.DataFrame:
         if isinstance(data, list):
             if len(data) == 0:
                 return pd.DataFrame()
-            # List of objects
-            return pd.json_normalize(data)
+            df = pd.json_normalize(data)
         elif isinstance(data, dict):
             # Check if dict contains a list that should be the main data
             # Common patterns: {"data": [...], "results": [...], "items": [...]}
+            df = None
             for key in ['data', 'results', 'items', 'records', 'rows', 'entries']:
                 if key in data and isinstance(data[key], list):
                     logger.info(f"Extracting list from '{key}' field")
-                    return pd.json_normalize(data[key])
-
-            # Single object or nested structure
-            return pd.json_normalize(data)
+                    df = pd.json_normalize(data[key])
+                    break
+            if df is None:
+                df = pd.json_normalize(data)
         else:
             # Primitive type, wrap in DataFrame
             return pd.DataFrame({'value': [data]})
+
+        return _ensure_scalar_columns(df)
 
     except json.JSONDecodeError as e:
         logger.error(f"JSON parsing error: {e}")
@@ -274,24 +276,39 @@ def _serialize_non_scalar(value: Any) -> Any:
 
 def _ensure_scalar_columns(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Ensure all DataFrame columns contain only scalar values.
-    Converts any remaining list or dict values to strings so that
-    DuckDB receives only VARCHAR-compatible types.
+    Ensure all DataFrame columns contain DuckDB-compatible values.
+
+    Two passes per object column:
+      1. Serialize any list/dict cells to strings.
+      2. If the column still mixes heterogeneous scalar types
+         (e.g. str + float), coerce every non-null cell to str so
+         DuckDB does not crash converting the dataframe to Arrow.
 
     Args:
-        df: DataFrame that may contain non-scalar cell values
+        df: DataFrame that may contain non-scalar or mixed-type cells
 
     Returns:
-        DataFrame with all scalar values
+        DataFrame with DuckDB-friendly columns
     """
     for col in df.columns:
-        if df[col].dtype == 'object':
-            has_non_scalar = df[col].apply(
-                lambda x: isinstance(x, (list, dict))
-            ).any()
-            if has_non_scalar:
-                logger.debug(f"Converting non-scalar values in column '{col}' to strings")
-                df[col] = df[col].apply(_serialize_non_scalar)
+        if df[col].dtype != 'object':
+            continue
+
+        has_non_scalar = df[col].apply(
+            lambda x: isinstance(x, (list, dict))
+        ).any()
+        if has_non_scalar:
+            logger.debug(f"Converting non-scalar values in column '{col}' to strings")
+            df[col] = df[col].apply(_serialize_non_scalar)
+
+        non_null = df[col].dropna()
+        if non_null.empty:
+            continue
+        type_set = {type(v) for v in non_null}
+        type_set.discard(type(None))
+        if len(type_set) > 1:
+            logger.debug(f"Coercing mixed-type column '{col}' to string ({type_set})")
+            df[col] = df[col].apply(lambda x: x if pd.isna(x) else str(x))
     return df
 
 

--- a/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_api_handler.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_api_handler.py
@@ -61,6 +61,10 @@ class MultiFormatAPIHandler(APIHandler):
             if headers and not isinstance(headers, dict):
                 raise ValueError("Headers must be a dictionary")
 
+            method = self.connection_args.get('method', 'GET').upper()
+            if method not in ('GET', 'POST'):
+                raise ValueError(f"Invalid method '{method}'. Must be GET or POST.")
+
             self.is_connected = True
             return StatusResponse(success=True)
 

--- a/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
@@ -3,6 +3,7 @@ Multi-Format API Table implementation.
 Handles fetching and parsing data from web APIs/pages in multiple formats.
 """
 
+import json
 import requests
 import pandas as pd
 from typing import List, Optional
@@ -21,6 +22,22 @@ from mindsdb.integrations.utilities.sql_utils import (
 from .format_parsers import parse_response
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_dict_arg(value, arg_name: str) -> dict:
+    """Connection args declared as ARG_TYPE.DICT may arrive as JSON strings
+    from the MindsDB UI form. Coerce to dict; tolerate empty/invalid input."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning(f"Connection arg '{arg_name}' is not a JSON object; ignoring.")
+        except json.JSONDecodeError:
+            logger.warning(f"Connection arg '{arg_name}' is not valid JSON; ignoring.")
+    return {}
 
 
 class MultiFormatAPITable(APIResource):
@@ -49,7 +66,6 @@ class MultiFormatAPITable(APIResource):
             pandas DataFrame with parsed data
         """
         # Extract URL from conditions
-        import json
         url = None
         headers = {}
         method = None
@@ -99,7 +115,7 @@ class MultiFormatAPITable(APIResource):
         # Fall back to connection-level method and body
         if not method:
             method = self.handler.connection_args.get('method', 'GET').upper()
-        connection_body = self.handler.connection_args.get('body', {})
+        connection_body = _coerce_dict_arg(self.handler.connection_args.get('body'), 'body')
         if connection_body:
             body = {**connection_body, **body}  # query-level keys override connection-level
 
@@ -118,7 +134,7 @@ class MultiFormatAPITable(APIResource):
 
         try:
             # Get default headers from connection args if available
-            connection_headers = self.handler.connection_args.get('headers', {})
+            connection_headers = _coerce_dict_arg(self.handler.connection_args.get('headers'), 'headers')
             if connection_headers:
                 headers = {**connection_headers, **headers}
 

--- a/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
@@ -49,8 +49,11 @@ class MultiFormatAPITable(APIResource):
             pandas DataFrame with parsed data
         """
         # Extract URL from conditions
+        import json
         url = None
         headers = {}
+        method = None
+        body = {}
         timeout = self.handler.connection_args.get('timeout', 30)
         max_content_size_mb = self.handler.connection_args.get('max_content_size', 100)
 
@@ -62,29 +65,43 @@ class MultiFormatAPITable(APIResource):
                     url = condition.value
                     condition.applied = True
                 elif column == 'headers':
-                    # Allow custom headers as JSON string
-                    import json
                     try:
                         headers = json.loads(condition.value)
-                    except:
+                    except Exception:
                         logger.warning(f"Invalid headers JSON: {condition.value}")
+                    condition.applied = True
+                elif column == 'method':
+                    method = condition.value.upper()
+                    condition.applied = True
+                elif column == 'body':
+                    try:
+                        body = json.loads(condition.value) if isinstance(condition.value, str) else condition.value
+                    except Exception:
+                        logger.warning(f"Invalid body JSON: {condition.value}")
                     condition.applied = True
                 elif column == 'timeout':
                     try:
                         timeout = int(condition.value)
-                    except:
+                    except Exception:
                         logger.warning(f"Invalid timeout value: {condition.value}")
                     condition.applied = True
                 elif column == 'max_content_size':
                     try:
                         max_content_size_mb = float(condition.value)
-                    except:
+                    except Exception:
                         logger.warning(f"Invalid max_content_size value: {condition.value}")
                     condition.applied = True
 
         # Use connection-level URL if query-level not provided
         if not url:
             url = self.handler.connection_args.get('url')
+
+        # Fall back to connection-level method and body
+        if not method:
+            method = self.handler.connection_args.get('method', 'GET').upper()
+        connection_body = self.handler.connection_args.get('body', {})
+        if connection_body:
+            body = {**connection_body, **body}  # query-level keys override connection-level
 
         if not url:
             raise ValueError(
@@ -109,25 +126,29 @@ class MultiFormatAPITable(APIResource):
             if 'User-Agent' not in headers:
                 headers['User-Agent'] = 'MindsDB Multi-Format API Handler/1.0'
 
-            # Stage 1: HEAD request to check Content-Length (fail fast)
-            try:
-                head_response = requests.head(url, headers=headers, timeout=min(10, timeout), allow_redirects=True)
-                content_length = head_response.headers.get('Content-Length')
+            if method == 'POST':
+                # POST requests: skip HEAD (many POST endpoints reject it), go straight to POST
+                response = requests.post(url, headers=headers, json=body or None, timeout=timeout, stream=True)
+            else:
+                # Stage 1: HEAD request to check Content-Length (fail fast)
+                try:
+                    head_response = requests.head(url, headers=headers, timeout=min(10, timeout), allow_redirects=True)
+                    content_length = head_response.headers.get('Content-Length')
 
-                if content_length:
-                    content_length = int(content_length)
-                    if content_length > max_content_size_bytes:
-                        raise ValueError(
-                            f"Content size ({content_length / 1024 / 1024:.2f} MB) exceeds maximum allowed "
-                            f"size ({max_content_size_mb} MB). Increase max_content_size parameter if needed."
-                        )
-                    logger.info(f"Content-Length: {content_length / 1024 / 1024:.2f} MB")
-            except requests.exceptions.RequestException as e:
-                # HEAD request failed, proceed with GET but monitor size
-                logger.warning(f"HEAD request failed: {e}. Proceeding with GET request.")
+                    if content_length:
+                        content_length = int(content_length)
+                        if content_length > max_content_size_bytes:
+                            raise ValueError(
+                                f"Content size ({content_length / 1024 / 1024:.2f} MB) exceeds maximum allowed "
+                                f"size ({max_content_size_mb} MB). Increase max_content_size parameter if needed."
+                            )
+                        logger.info(f"Content-Length: {content_length / 1024 / 1024:.2f} MB")
+                except requests.exceptions.RequestException as e:
+                    logger.warning(f"HEAD request failed: {e}. Proceeding with GET request.")
 
-            # Stage 2: GET request with streaming and size monitoring
-            response = requests.get(url, headers=headers, timeout=timeout, stream=True)
+                # Stage 2: GET request with streaming and size monitoring
+                response = requests.get(url, headers=headers, timeout=timeout, stream=True)
+
             response.raise_for_status()
 
             # Download in chunks and monitor size


### PR DESCRIPTION
## Summary

- Adds `method` connection arg (STR, `GET` or `POST`, default `GET`) — fully backward-compatible
- Adds `body` connection arg (DICT) for the default JSON request body sent with POST requests
- Both args are also settable per-query via the `WHERE` clause (consistent with existing `headers` pattern)
- POST requests skip the HEAD pre-check (many POST endpoints reject HEAD) and call `requests.post(json=body)`
- Body is shallow-merged: connection-level body provides defaults, query-level keys override them

## Usage

```sql
-- POST at query level
SELECT * FROM handler.data
WHERE url = 'https://api.example.com/search'
  AND method = 'POST'
  AND body = '{"query": "test", "limit": 10}';

-- POST at connection level
CREATE DATABASE my_api WITH ENGINE = 'multi_format_api', PARAMETERS = {
  "url": "https://api.example.com/search",
  "method": "POST",
  "body": {"api_key": "abc", "query": "default"}
};
SELECT * FROM my_api.data;
```