### PR TITLE
fix(meta-ad-library): default reached countries to US

### DIFF
--- a/mindsdb/integrations/handlers/meta_ad_library_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/meta_ad_library_handler/connection_args.py
@@ -25,7 +25,7 @@ connection_args = OrderedDict(
     },
     ad_reached_countries={
         "type": ARG_TYPE.STR,
-        "description": "Optional JSON array of reached countries. Defaults to [\"ALL\"].",
+        "description": "Optional JSON array of reached countries. Defaults to [\"US\"].",
         "label": "Reached Countries",
         "required": False,
     },
@@ -76,7 +76,7 @@ connection_args = OrderedDict(
 connection_args_example = OrderedDict(
     access_token="your_access_token_here",
     search_page_ids='["257702164651631"]',
-    ad_reached_countries='["ALL"]',
+    ad_reached_countries='["US"]',
     ad_type="ALL",
     ad_active_status="ALL",
     search_type="KEYWORD_UNORDERED",

--- a/mindsdb/integrations/handlers/meta_ad_library_handler/meta_ad_library_handler.py
+++ b/mindsdb/integrations/handlers/meta_ad_library_handler/meta_ad_library_handler.py
@@ -24,7 +24,7 @@ class MetaAdLibraryHandler(APIHandler):
     name = "meta_ad_library"
 
     DEFAULT_API_VERSION = "v24.0"
-    DEFAULT_AD_REACHED_COUNTRIES = ["ALL"]
+    DEFAULT_AD_REACHED_COUNTRIES = ["US"]
     DEFAULT_AD_TYPE = "ALL"
     DEFAULT_AD_ACTIVE_STATUS = "ALL"
     DEFAULT_SEARCH_TYPE = "KEYWORD_UNORDERED"
@@ -60,7 +60,8 @@ class MetaAdLibraryHandler(APIHandler):
         response = StatusResponse(success=False)
         try:
             self.connect()
-            self.fetch_ads(limit=1)
+            if self._has_configured_search_scope():
+                self.fetch_ads(limit=1)
             response.success = True
         except Exception as exc:  # noqa: BLE001
             logger.error("Error connecting to Meta Ad Library: %s", exc)
@@ -86,6 +87,28 @@ class MetaAdLibraryHandler(APIHandler):
         if has_local_filters and limit is not None:
             params["limit"] = self.DEFAULT_PAGE_SIZE
 
+        logger.info(
+            "meta_ad_library.fetch_ads.start search_page_ids=%s search_terms=%r "
+            "ad_reached_countries=%s ad_type=%s ad_active_status=%s limit=%s "
+            "has_local_filters=%s conditions=%s",
+            self._coerce_to_list(params.get("search_page_ids")),
+            params.get("search_terms"),
+            self._coerce_to_list(params.get("ad_reached_countries")),
+            params.get("ad_type"),
+            params.get("ad_active_status"),
+            params.get("limit"),
+            has_local_filters,
+            [
+                {
+                    "column": condition.column,
+                    "op": str(condition.op),
+                    "value": condition.value,
+                    "applied": getattr(condition, "applied", False),
+                }
+                for condition in conditions
+            ],
+        )
+
         response_rows: list[dict[str, Any]] = []
         next_cursor: str | None = None
         pages_scanned = 0
@@ -98,6 +121,13 @@ class MetaAdLibraryHandler(APIHandler):
             payload = self._request(request_params)
             pages_scanned += 1
             rows = payload.get("data", [])
+            logger.info(
+                "meta_ad_library.fetch_ads.page page_number=%s row_count=%s has_next_cursor=%s request=%s",
+                pages_scanned,
+                len(rows),
+                bool(payload.get("paging", {}).get("cursors", {}).get("after")),
+                self._redact_request_params(request_params),
+            )
             response_rows.extend(self._normalize_row(row) for row in rows)
 
             if not has_local_filters and limit is not None and len(response_rows) >= limit:
@@ -114,14 +144,12 @@ class MetaAdLibraryHandler(APIHandler):
         conditions: list[FilterCondition] | None,
         limit: int | None,
     ) -> dict[str, Any]:
+        conditions = conditions or []
         params: dict[str, Any] = {
             "fields": ",".join(AdsTable.COLUMNS),
             "access_token": self.access_token,
             "ad_reached_countries": json.dumps(
-                self._coerce_to_list(
-                    self.connection_data.get("ad_reached_countries"),
-                    fallback=self.DEFAULT_AD_REACHED_COUNTRIES,
-                )
+                self._resolve_ad_reached_countries(self.connection_data.get("ad_reached_countries"))
             ),
             "ad_type": self.connection_data.get("ad_type", self.DEFAULT_AD_TYPE),
             "ad_active_status": self.connection_data.get(
@@ -135,10 +163,14 @@ class MetaAdLibraryHandler(APIHandler):
         }
 
         search_page_ids = self._coerce_to_list(self.connection_data.get("search_page_ids"))
+        if not search_page_ids:
+            search_page_ids = self._extract_page_id_scope(conditions)
         if search_page_ids:
             params["search_page_ids"] = json.dumps(search_page_ids)
 
         search_terms = self.connection_data.get("search_terms")
+        if not search_terms:
+            search_terms = self._extract_page_name_scope(conditions)
         if search_terms:
             params["search_terms"] = search_terms
             params["search_type"] = self.connection_data.get(
@@ -154,7 +186,12 @@ class MetaAdLibraryHandler(APIHandler):
         if publisher_platforms:
             params["publisher_platforms"] = json.dumps(publisher_platforms)
 
-        date_min, date_max = self._extract_delivery_date_bounds(conditions or [])
+        if not search_page_ids and not search_terms:
+            raise ValueError(
+                "Meta Ad Library queries require a datasource search scope or a WHERE filter on page_id/page_name."
+            )
+
+        date_min, date_max = self._extract_delivery_date_bounds(conditions)
         if date_min is not None:
             params["ad_delivery_date_min"] = date_min.isoformat()
         if date_max is not None:
@@ -166,11 +203,70 @@ class MetaAdLibraryHandler(APIHandler):
     def _has_unapplied_conditions(conditions: list[FilterCondition]) -> bool:
         return any(not getattr(condition, "applied", False) for condition in conditions)
 
+    def _has_configured_search_scope(self) -> bool:
+        return bool(self._coerce_to_list(self.connection_data.get("search_page_ids"))) or bool(
+            self.connection_data.get("search_terms")
+        )
+
+    @staticmethod
+    def _extract_page_id_scope(conditions: list[FilterCondition]) -> list[str]:
+        page_ids: list[str] = []
+
+        for condition in conditions:
+            if condition.column != "page_id":
+                continue
+
+            values: list[Any] | None = None
+            if condition.op == FilterOperator.EQUAL:
+                values = [condition.value]
+            elif condition.op == FilterOperator.IN and isinstance(condition.value, list):
+                values = condition.value
+
+            if values is None:
+                continue
+
+            normalized = [str(value).strip() for value in values if str(value).strip()]
+            if not normalized:
+                continue
+
+            condition.applied = True
+            page_ids.extend(normalized)
+
+        return page_ids
+
+    @staticmethod
+    def _extract_page_name_scope(conditions: list[FilterCondition]) -> str | None:
+        for condition in conditions:
+            if condition.column != "page_name":
+                continue
+            if condition.op not in {FilterOperator.EQUAL, FilterOperator.LIKE}:
+                continue
+            if not isinstance(condition.value, str):
+                continue
+
+            search_terms = condition.value.strip()
+            if not search_terms:
+                continue
+
+            if condition.op == FilterOperator.LIKE:
+                search_terms = search_terms.replace("%", "").strip()
+                if not search_terms:
+                    continue
+
+            return search_terms
+
+        return None
+
     def _request(self, params: dict[str, Any]) -> dict[str, Any]:
         if self.session is None:
             raise RuntimeError("Handler is not connected. Call connect() first.")
         response = self.session.get(self.base_url, params=params, timeout=30)
         if response.ok:
+            logger.info(
+                "meta_ad_library.request.success status_code=%s request=%s",
+                response.status_code,
+                self._redact_request_params(params),
+            )
             return response.json()
 
         message = response.text
@@ -182,7 +278,22 @@ class MetaAdLibraryHandler(APIHandler):
         except ValueError:
             pass
 
+        logger.error(
+            "meta_ad_library.request.failure status_code=%s request=%s response_text=%s",
+            response.status_code,
+            self._redact_request_params(params),
+            message,
+        )
+
         raise RuntimeError(f"Meta Ad Library request failed ({response.status_code}): {message}")
+
+    @staticmethod
+    def _redact_request_params(params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in params.items()
+            if key != "access_token"
+        }
 
     def _normalize_row(self, row: dict[str, Any]) -> dict[str, Any]:
         normalized: dict[str, Any] = {}
@@ -261,6 +372,17 @@ class MetaAdLibraryHandler(APIHandler):
                 condition.applied = True
 
         return date_min, date_max
+
+    @staticmethod
+    def _resolve_ad_reached_countries(value: Any) -> list[str]:
+        countries = MetaAdLibraryHandler._coerce_to_list(
+            value,
+            fallback=MetaAdLibraryHandler.DEFAULT_AD_REACHED_COUNTRIES,
+        )
+        normalized = [country.strip().upper() for country in countries if str(country).strip()]
+        if not normalized or "ALL" in normalized:
+            return list(MetaAdLibraryHandler.DEFAULT_AD_REACHED_COUNTRIES)
+        return normalized
 
     @staticmethod
     def _coerce_to_list(value: Any, fallback: list[str] | None = None) -> list[str]:

--- a/tests/unit/handlers/test_meta_ad_library.py
+++ b/tests/unit/handlers/test_meta_ad_library.py
@@ -56,7 +56,7 @@ def handler():
         connection_data={
             "access_token": "meta_token",
             "search_page_ids": ["257702164651631"],
-            "ad_reached_countries": ["ALL"],
+            "ad_reached_countries": ["US"],
             "ad_type": "ALL",
             "ad_active_status": "ALL",
         },
@@ -93,46 +93,48 @@ def test_check_connection_success(handler):
     session.get.assert_called_once()
 
 
-def test_check_connection_fails_when_no_search_scope():
-    """Meta API returns 400 when neither search_page_ids nor search_terms is provided."""
+def test_check_connection_succeeds_when_no_search_scope():
     handler = MetaAdLibraryHandler(
         "meta_ad_library",
         connection_data={"access_token": "meta_token"},
     )
-    session = MagicMock()
-    session.get.return_value = _build_json_response(
-        {
-            "error": {
-                "message": "A search_terms or search_page_ids parameter is required",
-                "type": "GraphMethodException",
-                "code": 100,
-            }
-        },
-        status_code=400,
-    )
 
     with patch(
         "mindsdb.integrations.handlers.meta_ad_library_handler.meta_ad_library_handler.requests.Session",
-        return_value=session,
+        return_value=MagicMock(),
     ):
         response = handler.check_connection()
 
     assert isinstance(response, StatusResponse)
-    assert response.success is False
-    assert "search_terms or search_page_ids" in response.error_message
-    session.get.assert_called_once()
+    assert response.success is True
+    assert response.error_message is None
 
 
 def test_build_request_params_for_page_scope_does_not_send_search_type(handler):
     params = handler._build_request_params(conditions=[], limit=25)
 
     assert params["access_token"] == "meta_token"
-    assert params["ad_reached_countries"] == '["ALL"]'
+    assert params["ad_reached_countries"] == '["US"]'
     assert params["ad_type"] == "ALL"
     assert params["ad_active_status"] == "ALL"
     assert params["limit"] == 25
     assert params["search_page_ids"] == '["257702164651631"]'
     assert "search_type" not in params
+
+
+def test_build_request_params_converts_all_reached_countries_to_us():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "search_page_ids": ["257702164651631"],
+            "ad_reached_countries": ["ALL"],
+        },
+    )
+
+    params = handler._build_request_params(conditions=[], limit=10)
+
+    assert params["ad_reached_countries"] == '["US"]'
 
 
 def test_build_request_params_for_keyword_scope_sends_default_search_type():
@@ -141,7 +143,7 @@ def test_build_request_params_for_keyword_scope_sends_default_search_type():
         connection_data={
             "access_token": "meta_token",
             "search_terms": "software engineer",
-            "ad_reached_countries": ["ALL"],
+            "ad_reached_countries": ["US"],
         },
     )
 
@@ -150,6 +152,58 @@ def test_build_request_params_for_keyword_scope_sends_default_search_type():
     assert params["search_terms"] == "software engineer"
     assert params["search_type"] == "KEYWORD_UNORDERED"
     assert "search_page_ids" not in params
+
+
+def test_build_request_params_uses_page_id_filter_as_runtime_scope():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "ad_reached_countries": ["US"],
+        },
+    )
+    conditions = [
+        FilterCondition("page_id", FilterOperator.EQUAL, "257702164651631"),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["search_page_ids"] == '["257702164651631"]'
+    assert conditions[0].applied is True
+    assert "search_terms" not in params
+
+
+def test_build_request_params_uses_page_name_filter_as_runtime_scope():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "ad_reached_countries": ["US"],
+        },
+    )
+    conditions = [
+        FilterCondition("page_name", FilterOperator.EQUAL, "AG1 by Athletic Greens"),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["search_terms"] == "AG1 by Athletic Greens"
+    assert params["search_type"] == "KEYWORD_UNORDERED"
+    assert conditions[0].applied is False
+    assert "search_page_ids" not in params
+
+
+def test_build_request_params_requires_scope_when_missing():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "ad_reached_countries": ["US"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="page_id/page_name"):
+        handler._build_request_params(conditions=[], limit=10)
 
 
 def test_build_request_params_translates_delivery_date_bounds(handler):
@@ -252,6 +306,7 @@ def test_fetch_ads_does_not_pre_limit_when_local_filters_remain(handler):
 
     assert [row["id"] for row in rows] == ["1", "2", "3", "4", "5"]
     assert session.get.call_args.kwargs["params"]["limit"] == handler.DEFAULT_PAGE_SIZE
+    assert session.get.call_args.kwargs["params"]["search_terms"] == "Pulse Media"
     assert conditions[0].applied is False
 
 


### PR DESCRIPTION
## Contexto
O handler da Meta Ad Library no MindsDB precisava ficar mais confiável para consultas reais sobre páginas e criativos públicos, especialmente nos cenários em que o datasource não nasce com um escopo rígido pré-configurado e o recorte da busca precisa ser resolvido a partir da própria query.

Na prática, isso aparecia em dois pontos. Primeiro, o comportamento padrão de `ad_reached_countries` ainda permitia configurações amplas demais para o uso que estamos validando localmente, o que reduzia a previsibilidade dos resultados. Segundo, o handler precisava aceitar melhor o recorte vindo da query, sem obrigar que todo datasource já trouxesse `search_page_ids` ou `search_terms` salvos de antemão.

## O que foi implementado
O PR ajusta o handler `meta_ad_library` para tornar o comportamento default mais aderente ao fluxo real do produto e às consultas que o Data Agent faz sobre a tabela `ads`.

O primeiro ajuste foi padronizar o default de `ad_reached_countries` para `US` e normalizar em runtime configurações legadas que ainda chegarem como `ALL`. Com isso, o handler passa a trabalhar com um recorte compatível com o fixture operacional que estamos usando e evita respostas vazias ou pouco estáveis causadas por uma configuração excessivamente ampla.

O segundo ajuste foi reforçar a resolução de escopo no momento da query. Quando o datasource não traz `search_page_ids` ou `search_terms` persistidos, o handler passa a derivar esse escopo a partir de filtros sobre `page_id` ou `page_name`, preservando a ideia de datasource aberto e deixando o recorte da consulta sob controle da própria pergunta executada.

O PR também mantém o caminho de observabilidade do handler mais explícito, registrando o request efetivo enviado para a Meta, os filtros aplicados, o comportamento de paginação e a distinção entre filtros remotos e filtros locais quando existe `LIMIT` combinado com condições que o provider não consegue empurrar para a API.

## Arquitetura e decisões
A principal decisão foi manter o handler orientado a um datasource aberto, em vez de exigir que toda criação de connector persista um escopo fixo. Isso deixa o MindsDB mais alinhado ao uso do Data Agent, onde a pergunta do usuário deve ser capaz de determinar o recorte final por `page_id` ou `page_name`.

A normalização de `ad_reached_countries` foi colocada no próprio handler, em runtime, em vez de depender de migração corretiva ou recriação de conectores já existentes. Assim, o comportamento fica consistente tanto para novos datasources quanto para configurações legadas ainda presentes no ambiente.

Outra decisão importante foi preservar a diferença entre filtros que podem ser traduzidos para a API da Meta e filtros que continuam sendo aplicados localmente. O handler amplia a janela de coleta quando há filtros locais com `LIMIT`, mas sem perder o controle sobre custo e paginação, o que evita resultados artificialmente vazios em consultas mais específicas.

## Pontos de atenção para review
Vale revisar se o default para `US` está coerente com o recorte de produto que queremos sustentar neste rollout e se existe algum fluxo que ainda dependa explicitamente de `ALL` como comportamento esperado.

Também é importante validar se a resolução de escopo a partir de `page_id` e `page_name` cobre bem os cenários principais do Data Agent sem introduzir ambiguidade entre filtros usados para buscar dados na Meta e filtros aplicados apenas localmente no handler.
