### PR TITLE
fix: aplicar pushdown de ad_reached_countries no Meta Ad Library

### DIFF
--- a/mindsdb/integrations/handlers/meta_ad_library_handler/meta_ad_library_handler.py
+++ b/mindsdb/integrations/handlers/meta_ad_library_handler/meta_ad_library_handler.py
@@ -145,12 +145,16 @@ class MetaAdLibraryHandler(APIHandler):
         limit: int | None,
     ) -> dict[str, Any]:
         conditions = conditions or []
+        ad_reached_countries = self._extract_ad_reached_countries_scope(conditions)
+        if not ad_reached_countries:
+            ad_reached_countries = self._resolve_ad_reached_countries(
+                self.connection_data.get("ad_reached_countries")
+            )
+
         params: dict[str, Any] = {
             "fields": ",".join(AdsTable.COLUMNS),
             "access_token": self.access_token,
-            "ad_reached_countries": json.dumps(
-                self._resolve_ad_reached_countries(self.connection_data.get("ad_reached_countries"))
-            ),
+            "ad_reached_countries": json.dumps(ad_reached_countries),
             "ad_type": self.connection_data.get("ad_type", self.DEFAULT_AD_TYPE),
             "ad_active_status": self.connection_data.get(
                 "ad_active_status",
@@ -256,6 +260,39 @@ class MetaAdLibraryHandler(APIHandler):
             return search_terms
 
         return None
+
+    @classmethod
+    def _extract_ad_reached_countries_scope(
+        cls,
+        conditions: list[FilterCondition],
+    ) -> list[str]:
+        countries: list[str] = []
+
+        for condition in conditions:
+            if condition.column != "ad_reached_countries":
+                continue
+
+            values: list[Any] | None = None
+            if condition.op == FilterOperator.EQUAL:
+                values = cls._coerce_to_list(condition.value)
+            elif condition.op == FilterOperator.IN and isinstance(condition.value, list):
+                values = condition.value
+
+            if values is None:
+                continue
+
+            cleaned_values = [str(value).strip() for value in values if str(value).strip()]
+            if not cleaned_values:
+                continue
+
+            normalized = cls._resolve_ad_reached_countries(cleaned_values)
+            if not normalized:
+                continue
+
+            condition.applied = True
+            countries.extend(normalized)
+
+        return list(dict.fromkeys(countries))
 
     def _request(self, params: dict[str, Any]) -> dict[str, Any]:
         if self.session is None:

--- a/tests/unit/handlers/test_meta_ad_library.py
+++ b/tests/unit/handlers/test_meta_ad_library.py
@@ -173,6 +173,82 @@ def test_build_request_params_uses_page_id_filter_as_runtime_scope():
     assert "search_terms" not in params
 
 
+def test_build_request_params_uses_country_filter_as_runtime_scope():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "search_page_ids": ["257702164651631"],
+            "ad_reached_countries": ["DE"],
+        },
+    )
+    conditions = [
+        FilterCondition("ad_reached_countries", FilterOperator.EQUAL, "us"),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["ad_reached_countries"] == '["US"]'
+    assert conditions[0].applied is True
+
+
+def test_build_request_params_uses_country_in_filter_as_runtime_scope():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "search_page_ids": ["257702164651631"],
+            "ad_reached_countries": ["DE"],
+        },
+    )
+    conditions = [
+        FilterCondition("ad_reached_countries", FilterOperator.IN, ["ca", "us", "CA"]),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["ad_reached_countries"] == '["CA", "US"]'
+    assert conditions[0].applied is True
+
+
+def test_build_request_params_accepts_json_encoded_country_filter():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "search_page_ids": ["257702164651631"],
+            "ad_reached_countries": ["DE"],
+        },
+    )
+    conditions = [
+        FilterCondition("ad_reached_countries", FilterOperator.EQUAL, '["US"]'),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["ad_reached_countries"] == '["US"]'
+    assert conditions[0].applied is True
+
+
+def test_build_request_params_ignores_empty_country_filter_and_keeps_connection_scope():
+    handler = MetaAdLibraryHandler(
+        "meta_ad_library",
+        connection_data={
+            "access_token": "meta_token",
+            "search_page_ids": ["257702164651631"],
+            "ad_reached_countries": ["DE"],
+        },
+    )
+    conditions = [
+        FilterCondition("ad_reached_countries", FilterOperator.EQUAL, " "),
+    ]
+
+    params = handler._build_request_params(conditions=conditions, limit=10)
+
+    assert params["ad_reached_countries"] == '["DE"]'
+    assert getattr(conditions[0], "applied", False) is False
+
+
 def test_build_request_params_uses_page_name_filter_as_runtime_scope():
     handler = MetaAdLibraryHandler(
         "meta_ad_library",


### PR DESCRIPTION
## Contexto

A investigação do conector `meta_ad_library` mostrou que o Data Agent estava gerando consultas com `WHERE ad_reached_countries = ...`, mas o handler do MindsDB não tratava esse filtro como parte da request à Meta API. Na prática, o campo acabava sendo interpretado como se fosse uma coluna local da tabela `ads`, o que abria espaço para binder errors e para queda de comportamento para consultas mais amplas sem o filtro de país desejado.

## O que foi implementado

Implementei a extração de `ad_reached_countries` a partir das conditions SQL no handler `meta_ad_library`, com suporte a `EQUAL` e `IN`. Quando esse filtro aparece na query, ele passa a ser normalizado e enviado como parâmetro da request para a Meta API, com marcação de `applied=True` para evitar que o mecanismo local tente reaplicar a condição como se ela fosse uma coluna do dataframe.

Também cobri esse comportamento com testes unitários para os cenários principais: filtro simples, lista de países, valor JSON serializado e filtro vazio, garantindo que o handler mantenha o escopo original do datasource quando não houver país válido para fazer pushdown.

## Arquitetura e decisões

A decisão aqui foi tratar `ad_reached_countries` como filtro de request-time, e não como coluna da tabela `ads`. Isso preserva o contrato real da Meta Ad Library API e evita modelar como row-level data algo que, semanticamente, pertence à busca e não ao resultado por linha.

Também mantive a precedência da query sobre a configuração persistida do datasource: quando o SQL explicita `ad_reached_countries`, esse valor deve vencer o escopo administrativo salvo na conexão. Quando a query não fornece um filtro válido, o handler continua usando o escopo já configurado na connection data.

## Pontos de atenção para review

O principal ponto de review é validar se a extração de `ad_reached_countries` cobre bem o shape de conditions que o parser do MindsDB entrega para `EQUAL` e `IN`, sem introduzir efeitos colaterais em outros filtros já suportados pelo handler.

Também vale revisar a decisão de não expor `ad_reached_countries` como coluna selecionável da tabela, já que a mudança assume explicitamente que esse campo deve existir apenas como filtro de pushdown e não como dado retornado no schema do datasource.