### PR TITLE
Evita decodificar conteúdo em consultas de metadados do GitHub

### DIFF
--- a/mindsdb/integrations/handlers/github_handler/github_tables.py
+++ b/mindsdb/integrations/handlers/github_handler/github_tables.py
@@ -1115,12 +1115,27 @@ class GithubPagesBuildsTable(APIResource):
 
 class GithubFilesTable(APIResource):
 
-    def get_path(self, repo, path, file_matches=None, file_not_matches=None, limit=None):
+    def get_path(
+        self,
+        repo,
+        path,
+        file_matches=None,
+        file_not_matches=None,
+        limit=None,
+        include_content=True,
+    ):
 
         res = []
         for item in list(repo.get_contents(path)):
             if item.type == "dir":
-                subres = self.get_path(repo, item.path, file_matches, file_not_matches, limit)
+                subres = self.get_path(
+                    repo,
+                    item.path,
+                    file_matches,
+                    file_not_matches,
+                    limit,
+                    include_content,
+                )
                 res.extend(subres)
                 limit -= len(subres)
             else:
@@ -1141,8 +1156,17 @@ class GithubFilesTable(APIResource):
                     file = {
                         'path': item.path,
                         'name': item.name,
-                        'content': item.decoded_content,
                     }
+                    if include_content:
+                        try:
+                            file['content'] = item.decoded_content
+                        except AssertionError as exc:
+                            logger.warning(
+                                "Could not decode GitHub file content for %s: %s",
+                                item.path,
+                                exc,
+                            )
+                            file['content'] = None
                     res.append(file)
                     limit -= 1
             if limit <= 0:
@@ -1187,9 +1211,18 @@ class GithubFilesTable(APIResource):
         if len(file_not_matches) == 0:
             file_not_matches = None
 
+        include_content = not targets or 'content' in targets
+
         all_res = []
         for repo in repos:
-            res = self.get_path(repo, path, file_matches, file_not_matches, limit - len(all_res))
+            res = self.get_path(
+                repo,
+                path,
+                file_matches,
+                file_not_matches,
+                limit - len(all_res),
+                include_content,
+            )
             for item in res:
                 item["repository"] = repo.full_name
             all_res.extend(res)


### PR DESCRIPTION
## Contexto

O conector GitHub expõe a tabela files para descoberta e leitura de arquivos do repositório. No fluxo de AI Dashboards, consultas simples de documentação e runbooks podem primeiro precisar listar caminhos e nomes antes de decidir quais arquivos ler.

Antes desta mudança, GithubFilesTable sempre acessava decoded_content para cada arquivo retornado, mesmo quando a query só selecionava metadados como path e name. Isso torna consultas de descoberta frágeis: qualquer arquivo com encoding ausente ou não-base64 pode derrubar a query inteira com unsupported encoding.

## O que foi implementado

A tabela files agora diferencia consulta de metadados de consulta de conteúdo. Quando a seleção não pede content, o handler retorna apenas os dados de arquivo necessários sem tentar decodificar o conteúdo. Quando content é pedido, o handler continua lendo o conteúdo como antes.

Também foi adicionado tratamento por linha para falha de decode causada por AssertionError. Em vez de quebrar a consulta inteira, o arquivo continua sendo retornado com content = None, preservando path, name e repository para o consumidor decidir como lidar com aquele item.

## Arquitetura e decisões

A mudança fica restrita ao GithubFilesTable e mantém o contrato público atual da tabela, sem adicionar colunas novas. O comportamento padrão de SELECT * ou ausência de targets continua incluindo conteúdo, preservando compatibilidade com consumidores existentes.

A decisão principal é usar targets como fronteira entre descoberta e leitura. Isso evita trabalho desnecessário em queries metadata-only e reduz o impacto de arquivos binários, symlinks, submodules ou objetos da API do GitHub sem conteúdo base64.

## Pontos de atenção para review

- Confirmar que targets vazio deve continuar significando leitura de conteúdo, para manter compatibilidade com o comportamento anterior.
- Confirmar que retornar content = None em decode unsupported é preferível a remover a linha ou falhar a query inteira.
- Esta PR não adiciona novas colunas de status/erro; isso pode ser evoluído depois se quisermos expor content_status/content_error.