### PR TITLE
fix(kb): resolve provider API key from env var over stored key

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -74,6 +74,17 @@ class OpenAIHandler(BaseMLEngine):
         self.api_key_name = getattr(self, "api_key_name", self.name)
         self.api_base = getattr(self, "api_base", OPENAI_API_BASE)
 
+    def _resolve_api_key(self, args: dict) -> Text:
+        """Resolve the API key with the environment variable taking precedence over
+        any key stored in the model args. This lets a rotated key be updated in one
+        place (the env) without recreating models/knowledge bases that stored the old
+        key. Falls back to the standard resolution chain when no env var is set.
+        """
+        env_api_key = os.getenv(f"{self.api_key_name.upper()}_API_KEY") or os.getenv(f"{self.api_key_name.lower()}_api_key")
+        if env_api_key:
+            return env_api_key
+        return get_api_key(self.api_key_name, args, self.engine_storage)
+
     def create_engine(self, connection_args: Dict) -> None:
         """
         Validate the OpenAI API credentials on engine creation.
@@ -231,7 +242,7 @@ class OpenAIHandler(BaseMLEngine):
         args = args["using"]
         args["target"] = target
         try:
-            api_key = get_api_key(self.api_key_name, args, self.engine_storage)
+            api_key = self._resolve_api_key(args)
             connection_args = self.engine_storage.get_connection_args()
             api_base = (
                 args.get("api_base")
@@ -434,7 +445,7 @@ class OpenAIHandler(BaseMLEngine):
         # remove prompts without signal from completion queue
         prompts = [j for i, j in enumerate(prompts) if i not in empty_prompt_ids]
 
-        api_key = get_api_key(self.api_key_name, args, self.engine_storage)
+        api_key = self._resolve_api_key(args)
         api_args = {k: v for k, v in api_args.items() if v is not None}  # filter out non-specified api args
         completion = self._completion(model_name, prompts, api_key, api_args, args, df)
 
@@ -851,7 +862,7 @@ class OpenAIHandler(BaseMLEngine):
         # TODO: Update to use update() artifacts
 
         args = self.model_storage.json_get("args")
-        api_key = get_api_key(self.api_key_name, args, self.engine_storage)
+        api_key = self._resolve_api_key(args)
         if attribute == "args":
             return pd.DataFrame(args.items(), columns=["key", "value"])
         elif attribute == "metadata":
@@ -899,7 +910,7 @@ class OpenAIHandler(BaseMLEngine):
         """  # noqa
         args = args if args else {}
 
-        api_key = get_api_key(self.api_key_name, args, self.engine_storage)
+        api_key = self._resolve_api_key(args)
 
         using_args = args.pop("using") if "using" in args else {}
 

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from typing import Dict, List, Optional, Any, Text, Tuple, Union
 import json
 import decimal
@@ -91,9 +92,17 @@ def get_reranking_model_from_params(reranking_model_params: dict):
     # Work on a copy; do not mutate caller's dict
     params_copy = copy.deepcopy(reranking_model_params)
 
-    # Handle API key if not provided
+    # Handle API key. The environment variable takes precedence over any api_key
+    # stored in the reranking_model params, so a rotated key can be updated in one
+    # place (the env) without recreating knowledge bases that stored the old key.
     provider = params_copy.get("provider", "openai").lower()
-    if "api_key" not in params_copy:
+    env_var_names = [f"{provider.upper()}_API_KEY", f"{provider}_api_key"]
+    if provider in ("gemini", "google"):
+        env_var_names += ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    env_api_key = next((os.getenv(name) for name in env_var_names if os.getenv(name)), None)
+    if env_api_key:
+        params_copy["api_key"] = env_api_key
+    elif "api_key" not in params_copy:
         params_copy["api_key"] = get_api_key(provider, params_copy, strict=False)
 
     # Handle model_name -> model alias for backward compatibility

--- a/mindsdb/interfaces/knowledge_base/llm_client.py
+++ b/mindsdb/interfaces/knowledge_base/llm_client.py
@@ -76,7 +76,17 @@ class LLMClient:
         if self.provider == "google":
             self.provider = "gemini"
 
-        if "api_key" not in params:
+        # The environment variable takes precedence over any api_key stored in the
+        # knowledge base params. This lets a rotated key be updated in one place (the
+        # env) without recreating every knowledge base that stored the old key.
+        env_var_names = [f"{self.provider.upper()}_API_KEY", f"{self.provider.lower()}_api_key"]
+        if self.provider == "gemini":
+            # provider is normalized from "google" above; the conventional env var is GOOGLE_API_KEY
+            env_var_names += ["GOOGLE_API_KEY", "google_api_key"]
+        env_api_key = next((os.getenv(name) for name in env_var_names if os.getenv(name)), None)
+        if env_api_key:
+            params["api_key"] = env_api_key
+        elif "api_key" not in params:
             api_key = get_api_key(self.provider, params, strict=False)
             if api_key is not None:
                 params["api_key"] = api_key


### PR DESCRIPTION
## Problem

Knowledge bases persist the OpenAI/Gemini API key **at creation time** in up to three places — the KB `params` JSON (`embedding_model` / `reranking_model`), and, for ML-handler-backed embedding models, the model's own args. After we rotated all OpenAI keys, existing KBs kept using the stale stored key and failed with:

> `401 - Incorrect API key provided: sk-proj-…`

The stored key shadows the environment variable because `get_api_key` gives creation-time args priority over env vars.

## Change

Make the environment variable take precedence over any stored key on **all** KB key-resolution paths, so a rotated key can be updated in one place (the env) without recreating knowledge bases:

- **`llm_client.py`** — embedding model prefers `{PROVIDER}_API_KEY` (gemini also honors `GOOGLE_API_KEY`) before the stored `api_key`.
- **`controller.py`** — reranking model uses the same env-first resolution; adds the missing `import os`.
- **`openai_handler.py`** — adds `_resolve_api_key()` (env-first, keyed off `api_key_name` so provider subclasses stay correct) and routes the predict / describe / validate / finetune sites through it.

Scoped to the KB + OpenAI-handler paths deliberately; the global `get_api_key` precedence is left unchanged.

## Behavioral note

For OpenAI models, the env var now overrides even an inference-time `USING api_key='...'`. Intended for a single-source-of-truth setup, but flagging it as a genuine precedence change on the OpenAI ML engine.

## Deploy

Requires `OPENAI_API_KEY` (and `GOOGLE_API_KEY`) present in the container env. In the dev compose this is wired via `env_file: ./mindsdb/.env` on the `mindsdb` service (that compose lives outside this repo, so it's not part of this diff).

## Follow-up (discussed, not in this PR)

The more robust fix is to **stop persisting the secret at creation** and scrub existing rows (KB params, embedding-model args, and the `openai` ML engine connection args), after which env becomes the sole source of truth and these env-first overrides can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)