### PR TITLE
Achata JSON do multi_format_api com underscore para colunas compatíveis com DuckDB

### DIFF
--- a/mindsdb/integrations/handlers/multi_format_api_handler/format_parsers.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/format_parsers.py
@@ -175,7 +175,7 @@ def parse_json(content: str, record_path: Optional[str] = None, auto_explode: bo
 
     # Legacy single-row behavior for object payloads when explosion is disabled.
     if not auto_explode and isinstance(data, dict):
-        return _ensure_scalar_columns(pd.json_normalize(data))
+        return _ensure_scalar_columns(pd.json_normalize(data, sep='_'))
 
     records, chosen_path = _resolve_records(data, record_path)
     if records is None:
@@ -183,7 +183,11 @@ def parse_json(content: str, record_path: Optional[str] = None, auto_explode: bo
     if len(records) == 0:
         return pd.DataFrame()
 
-    df = pd.json_normalize(records, sep='.')
+    # Flatten nested dicts with an underscore separator (e.g. day_c), NOT a dot.
+    # MindsDB executes projections through DuckDB, where a dotted name like `day.c`
+    # is parsed as a struct/table qualifier (column `c` of `day`) instead of a
+    # column literally named "day.c" — and no quoting form survives that rewrite.
+    df = pd.json_normalize(records, sep='_')
 
     # Reattach top-level scalar siblings (status, count, request_id, ...) as
     # constant columns so envelope metadata is not lost. Skip the array key;


### PR DESCRIPTION
## Contexto

O handler `multi_format_api` explode o array de registros de uma resposta JSON em linhas e achata os objetos aninhados em colunas. O achatamento usava separador de **ponto** (`json_normalize(sep='.')`), gerando nomes como `day.c`, `prevDay.c`.

Esses nomes são inutilizáveis no caminho de consulta do MindsDB. A projeção é executada via DuckDB, e um nome com ponto é interpretado como **qualificador de struct/tabela** (coluna `c` de `day`) em vez de uma coluna chamada literalmente `day.c`. Nenhuma forma de citação resolve: aspas duplas viram literais de string e crases são removidas no rewrite antes da execução. Resultado observado em staging: `Binder Error: Referenced column "c" not found`.

## O que foi implementado

Troca o separador do `json_normalize` de ponto para **underscore** no caminho JSON, alinhando ao caminho XML que já fazia isso. Campos aninhados passam a virar `day_c`, `prevDay_c`, `lastQuote_P` — identificadores simples e selecionáveis diretamente, sem ambiguidade de citação.

A mudança cobre tanto a explosão de registros quanto o fallback de objeto único (auto_explode desligado), para manter a convenção consistente.

## Arquitetura e decisões

- Correção mínima e local: apenas o separador. A detecção do array de registros, o reattach de escalares de topo e o resto do pipeline permanecem inalterados.
- Underscore é a convenção que o próprio handler já adota no XML, então o comportamento fica uniforme entre formatos.

## Pontos de atenção para review

- Mudança de shape observável: consumidores que referenciavam colunas achatadas por nome com ponto passam a usar underscore.
- Validado com o snapshot real de mercado (~13k tickers): saída com 12.962 linhas e colunas `day_c`/`prevDay_c`/`lastQuote_P`, sem nomes com ponto.
- Do lado do mktplace, as instruções do conector e os prompts de SQL foram alinhados a esse formato em PR separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)