### PR TITLE
Expõe a mensagem de erro da API quando a requisição falha no multi_format_api

### DIFF
--- a/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
+++ b/mindsdb/integrations/handlers/multi_format_api_handler/multi_format_table.py
@@ -53,6 +53,34 @@ def _coerce_bool_arg(value, default: bool = True) -> bool:
     return text not in ('false', '0', 'no', 'off')
 
 
+def _extract_api_error_detail(error: requests.exceptions.RequestException) -> str:
+    """Pull the API's own error message out of a failed response body.
+
+    requests' HTTPError only stringifies the status line (e.g. "400 Client Error:
+    Bad Request for url: ..."), so the server's explanation is otherwise lost.
+    Many APIs return it as {"error": "..."} / {"message": "..."}. Returns a short
+    suffix to append to the raised error, or '' when no body is available.
+    """
+    response = getattr(error, 'response', None)
+    if response is None:
+        return ''
+    try:
+        body = (response.text or '').strip()
+    except Exception:  # defensive: some response objects can raise on .text
+        return ''
+    if not body:
+        return ''
+    try:
+        parsed = response.json()
+    except ValueError:
+        parsed = None
+    if isinstance(parsed, dict):
+        message = parsed.get('error') or parsed.get('message') or parsed.get('detail')
+        if message:
+            return f" | API error: {message}"
+    return f" | response body: {body[:500]}"
+
+
 class MultiFormatAPITable(APIResource):
     """
     Generic API table that fetches and parses data from URLs.
@@ -231,8 +259,9 @@ class MultiFormatAPITable(APIResource):
             mock_response = MockResponse(content_text, response.headers)
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"Request failed: {e}")
-            raise ValueError(f"Failed to fetch data from {url}: {e}")
+            detail = _extract_api_error_detail(e)
+            logger.error(f"Request failed: {e}{detail}")
+            raise ValueError(f"Failed to fetch data from {url}: {e}{detail}")
 
         # Parse response based on detected format
         try:


### PR DESCRIPTION
## Contexto

Quando uma requisição HTTP do handler `multi_format_api` falha, o erro propagado continha apenas a linha de status do `requests` (ex.: `400 Client Error: Bad Request for url: ...`). O corpo da resposta — onde as APIs normalmente explicam o motivo real — era descartado.

Isso obrigava a adivinhar a causa. Exemplo real: a API da massive.com responde `{"status":"ERROR","error":"API Key was not provided"}` (e mensagens análogas para parâmetros inválidos), mas nada disso chegava ao usuário; só aparecia o `400`/`401` genérico.

## O que foi implementado

Um helper que extrai a mensagem de erro do corpo da resposta que falhou e a anexa tanto ao erro levantado quanto ao log:

- se o corpo for JSON, usa `error` / `message` / `detail`;
- caso contrário, inclui o corpo bruto truncado (500 chars).

Sem corpo disponível, o comportamento é o de antes.

## Arquitetura e decisões

- Mudança pequena e localizada no tratamento de exceção do fetch; não altera o caminho de sucesso nem o parsing.
- Defensivo: tolera respostas sem corpo, corpo não-JSON e objetos de resposta que possam falhar ao ler `.text`.

## Pontos de atenção para review

- Validado contra a resposta real de erro da massive.com: a mensagem passa a incluir `| API error: API Key was not provided` em vez de só a linha de status.
- Cuidado usual: o corpo pode conter dados sensíveis; por isso é truncado. Se algum endpoint retornar segredos no corpo de erro, convém revisar o truncamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)